### PR TITLE
RFC: reduce progmem access overhead

### DIFF
--- a/pgmspace.nim
+++ b/pgmspace.nim
@@ -9,6 +9,26 @@ proc pgmReadDoubleWord*[T](address: ptr T): uint32 {.importc: "pgm_read_dword".}
 proc memcpyPgm*[T](dest: ptr T, src: ptr T, size: csize_t): ptr T {.importc: "memcpy_P".}
 {.pop.}
 
+proc `[]`*[T](src: ptr Progmem[T]): T {.noinit.} =
+    when sizeof(T) == 1:
+      result = cast[T](pgmReadByte(cast[ptr T](src)))
+    elif sizeof(T) == 2:
+      result = cast[T]( pgmReadWord(cast[ptr T](src)))
+    elif sizeof(T) == 4:
+      result = cast[T](pgmReadDoubleWord(cast[ptr T](src)))
+    else:
+      discard memcpyPgm(result.addr, cast[ptr T](src), sizeof(T).csize_t)
+
+proc readInto*[T](dst: var T, src: Progmem[T]) =
+    when sizeof(T) == 1:
+      dst = cast[T](pgmReadByte(cast[ptr T](src.unsafeAddr)))
+    elif sizeof(T) == 2:
+      dst = cast[T]( pgmReadWord(cast[ptr T](src.unsafeAddr)))
+    elif sizeof(T) == 4:
+      dst = cast[T](pgmReadDoubleWord(cast[ptr T](src.unsafeAddr)))
+    else:
+      discard memcpyPgm(dst.addr, cast[ptr T](src.unsafeAddr), sizeof(T).csize_t)
+
 template read*[T](data: Progmem[T]): T =
   cast[T](
     when sizeof(T) == 1:

--- a/pgmspace.nim
+++ b/pgmspace.nim
@@ -18,8 +18,10 @@ template read*[T](data: Progmem[T]): T =
     elif sizeof(T) == 4:
       pgmReadDoubleWord(cast[ptr T](data.unsafeAddr))
     else:
-      var x: T
-      memcpyPgm(x.addr, cast[ptr T](data.unsafeAddr), sizeof(T).csize_t)[])
+      var x {.noInit.} : T
+      discard memcpyPgm(x.addr, cast[ptr T](data.unsafeAddr), sizeof(T).csize_t)
+      x
+  )
 
 template len*[N, T](data: Progmem[array[N, T]]): untyped =
   array[N, T](data).len
@@ -49,8 +51,10 @@ macro createFieldReaders*(obj: typed): untyped =
           elif sizeof(`kind`) == 4:
             pgmReadDoubleWord(cast[ptr uint32](cast[int](x.unsafeAddr) + `obj`.offsetof(`name`)))
           else:
-            var x: T
-            memcpyPgm(x.addr, cast[ptr T](data.unsafeAddr), sizeof(T).csize_t)[])
+            var x {.noInit.} : T
+            discard memcpyPgm(x.addr, cast[ptr T](data.unsafeAddr), sizeof(T).csize_t)[]
+            x
+          )
 
 macro progmem*(definitions: untyped): untyped =
   #echo definitions.treeRepr


### PR DESCRIPTION
Hi! While trying out your excelent `pgmspace.nim` Nim module on a toy AVR project I found that PROGMEM access generated a number of unnecessary nimZeroMem() and nimCopyMem() calls. I'd like your feedback about these changes. BTW I think `pgmspace.nim` deserves its own repo or to live in a repo with other AVR specific helper modules.